### PR TITLE
fix: Handle ticket opened by a bot

### DIFF
--- a/linear-extract-reviewers.py
+++ b/linear-extract-reviewers.py
@@ -42,8 +42,10 @@ def main() -> None:
         creators = ",".join(
             email_mapping[response["creator"]["email"]]
             for response in responses["data"].values()
+            if response["creator"]
         )
-        print(f"::set-output name=CREATORS::{creators}")
+        if creators:
+            print(f"::set-output name=CREATORS::{creators}")
 
 
 main()


### PR DESCRIPTION
When ticket is opened by a bot, there is no author available.

Fixes MRGFY-1847