### PR TITLE
fix: filter out COMMENTED reviews

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,8 @@ runs:
       if: "${{ steps.extract.outputs.creators }}"
       run: |
         set -x
-        for creator in ${{steps.extract.outputs.creators}}; do
-          gh pr view ${{github.event.pull_request.html_url}} --json latestReviews |jq -e '.latestReviews[] | select(.author.login == "'${creator}'" and .state != "DISMISSED")' \
+        for creator in ${{steps.extract.outputs.creators}}; do  
+          gh pr view ${{github.event.pull_request.html_url}} --json latestReviews |jq -e '.latestReviews[] | select(.author.login == "'${creator}'" and .state != "DISMISSED" and .state != "COMMENTED")' \
           && \
             echo "Review of ${creator} has already been requested" \
           || \


### PR DESCRIPTION
If a review posts a APPROVAL or REQUEST CHANGES + a comment, a dismiss leaves the latest state in COMMENTED.
We want to filter that out since we want to re-request a review in the case just the comment is left in the review.