### PR TITLE
feat: Handle missing email mapping and support a default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ jobs:
            LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
            LINEAR_ISSUE_REGEX: "MRGFY-\d+"
            EMAIL_MAPPING: ${{ vars.EMAIL_MAPPING }}
+           DEFAULT_REVIEWER: "gh_username_or_team"
 ```
 
 The email mapping GitHub Action variables format is:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ on:
     types: [ "opened", "synchronize", "reopened", "edited" ]
 
 
-permissions: write-all
+permissions:
+  pull-requests: write
+  contents: read
 
 jobs:
   add-linear-author-as-reviewer:

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   GITHUB_TOKEN:
     required: true
     description: 'GitHub Token'
+  DEFAULT_REVIEWER: 
+    required: false
+    description: 'Default GH reviewer if no Linear author found'
+    default: ''
   EMAIL_MAPPING:
     required: true
     description: 'Linear Email to GitHub login mapping (one by line and separated by a space)'
@@ -30,6 +34,7 @@ runs:
       env:
         INPUT_LINEAR_API_KEY: ${{ inputs.LINEAR_API_KEY }}
         INPUT_LINEAR_ISSUE_REGEX: ${{ inputs.LINEAR_ISSUE_REGEX }}
+        INPUT_DEFAULT_REVIEWER: ${{ inputs.DEFAULT_REVIEWER }}
         INPUT_EMAIL_MAPPING: ${{ inputs.EMAIL_MAPPING }}
         INPUT_PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
         INPUT_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   GITHUB_TOKEN:
     required: true
     description: 'GitHub Token'
-  DEFAULT_REVIEWER: 
+  DEFAULT_REVIEWER:
     required: false
     description: 'Default GH reviewer if no Linear author found'
     default: ''
@@ -42,33 +42,19 @@ runs:
       if: "${{ steps.extract.outputs.creators }}"
       run: |
         set -x
-        # Parse creator string which may be comma-separated
-        for creator in ${{steps.extract.outputs.creators}}; do
-          # Check if creator contains commas (multiple reviewers)
-          if [[ "${creator}" == *","* ]]; then
-            # Split by comma and process each reviewer
-            IFS=',' read -ra reviewers <<< "${creator}"
-            for reviewer in "${reviewers[@]}"; do
-              # Trim whitespace
-              reviewer=$(echo "${reviewer}" | xargs)
-              (gh pr view ${{github.event.pull_request.html_url}} --json latestReviews | jq -e '.latestReviews[] | select(.author.login == "'${reviewer}'" and .state != "DISMISSED" and .state != "COMMENTED")' && \
-              echo "Review of ${reviewer} has already been requested") \
-              || \
-              (gh pr edit ${{github.event.pull_request.html_url}} --add-reviewer ${reviewer} && \
-              echo "Requested user review from ${reviewer} via 'gh' CLI") \
-              || \
-              echo "Failed to request review from ${reviewer}"
-            done
-          else
-            # Single reviewer
-            (gh pr view ${{github.event.pull_request.html_url}} --json latestReviews | jq -e '.latestReviews[] | select(.author.login == "'${creator}'" and .state != "DISMISSED" and .state != "COMMENTED")' && \
-            echo "Review of ${creator} has already been requested") \
-            || \
-            (gh pr edit ${{github.event.pull_request.html_url}} --add-reviewer ${creator} && \
-            echo "Requested user review from ${creator} via 'gh' CLI") \
-            || \
-            echo "Failed to request review from ${creator}"
-          fi
+        # Split creators string by commas and process each reviewer
+        creators="${{steps.extract.outputs.creators}}"
+        IFS=',' read -ra reviewers <<< "$creators"
+        for reviewer in "${reviewers[@]}"; do
+          # Trim whitespace
+          reviewer=$(echo "${reviewer}" | xargs)
+          (gh pr view ${{github.event.pull_request.html_url}} --json latestReviews | jq -e '.latestReviews[] | select(.author.login == "'${reviewer}'" and .state != "DISMISSED" and .state != "COMMENTED")' && \
+          echo "Review of ${reviewer} has already been requested") \
+          || \
+          (gh pr edit ${{github.event.pull_request.html_url}} --add-reviewer ${reviewer} && \
+          echo "Requested user review from ${reviewer} via 'gh' CLI") \
+          || \
+          echo "Failed to request review from ${reviewer}"
         done
       env:
         GITHUB_TOKEN: ${{inputs.GITHUB_TOKEN}}

--- a/action.yml
+++ b/action.yml
@@ -42,20 +42,33 @@ runs:
       if: "${{ steps.extract.outputs.creators }}"
       run: |
         set -x
-        for creator in ${{steps.extract.outputs.creators}}; do  
-          gh pr view ${{github.event.pull_request.html_url}} --json latestReviews |jq -e '.latestReviews[] | select(.author.login == "'${creator}'" and .state != "DISMISSED" and .state != "COMMENTED")' \
-          && \
-            echo "Review of ${creator} has already been requested" \
-          || \
-            curl -X POST \
-                -H "Content-type: application/json" \
-                -H "Accept: application/json" \
-                -H "Authorization: token $GITHUB_TOKEN" \
-                -d '{"reviewers": ["'${creator}'"]}' \
-                ${{github.event.pull_request.url}}/requested_reviewers
-            # This doesn't work because of https://github.com/cli/cli/issues/4844
-            # This may be fixed upstream now, as the related issue has been closed.
-            # gh pr edit ${{github.event.pull_request.html_url}} --add-reviewer $creator
+        # Parse creator string which may be comma-separated
+        for creator in ${{steps.extract.outputs.creators}}; do
+          # Check if creator contains commas (multiple reviewers)
+          if [[ "${creator}" == *","* ]]; then
+            # Split by comma and process each reviewer
+            IFS=',' read -ra reviewers <<< "${creator}"
+            for reviewer in "${reviewers[@]}"; do
+              # Trim whitespace
+              reviewer=$(echo "${reviewer}" | xargs)
+              (gh pr view ${{github.event.pull_request.html_url}} --json latestReviews | jq -e '.latestReviews[] | select(.author.login == "'${reviewer}'" and .state != "DISMISSED" and .state != "COMMENTED")' && \
+              echo "Review of ${reviewer} has already been requested") \
+              || \
+              (gh pr edit ${{github.event.pull_request.html_url}} --add-reviewer ${reviewer} && \
+              echo "Requested user review from ${reviewer} via 'gh' CLI") \
+              || \
+              echo "Failed to request review from ${reviewer}"
+            done
+          else
+            # Single reviewer
+            (gh pr view ${{github.event.pull_request.html_url}} --json latestReviews | jq -e '.latestReviews[] | select(.author.login == "'${creator}'" and .state != "DISMISSED" and .state != "COMMENTED")' && \
+            echo "Review of ${creator} has already been requested") \
+            || \
+            (gh pr edit ${{github.event.pull_request.html_url}} --add-reviewer ${creator} && \
+            echo "Requested user review from ${creator} via 'gh' CLI") \
+            || \
+            echo "Failed to request review from ${creator}"
+          fi
         done
       env:
         GITHUB_TOKEN: ${{inputs.GITHUB_TOKEN}}

--- a/linear-extract-reviewers.py
+++ b/linear-extract-reviewers.py
@@ -11,6 +11,7 @@ def main() -> None:
     linear_issue_regex = os.environ["INPUT_LINEAR_ISSUE_REGEX"]
     pull_request_details = os.environ.get("INPUT_PULL_REQUEST_TITLE", "") + " " + os.environ.get("INPUT_PULL_REQUEST_BODY", "")
     raw_mapping = os.environ["INPUT_EMAIL_MAPPING"]
+    default_reviewer = os.environ.get("INPUT_DEFAULT_REVIEWER", "")
 
     email_mapping = {}
     for line in raw_mapping.split("\n"):
@@ -48,13 +49,24 @@ def main() -> None:
             sys.exit(1)
 
         try:
-            creators = ",".join(
-                email_mapping[response["creator"]["email"]]
-                for response in response_json["data"].values()
-                if response.get("creator") and response["creator"].get("email")
-            )
+            creators = []
+            for response in response_json["data"].values():
+                if response.get("creator") and response["creator"].get("email"):
+                    email = response["creator"]["email"]
+                    if email in email_mapping:
+                        creators.append(email_mapping[email])
+                    elif default_reviewer:
+                        print(f"The ticket owner does not appear in the mapping variable. Using default reviewer: {default_reviewer}", file=sys.stderr)
+                        creators.append(default_reviewer)
+                    else:
+                        print("The ticket owner does not appear in the mapping variable.", file=sys.stderr)
+                        return
+                elif default_reviewer:
+                    print(f"No creator email found for ticket. Using default reviewer: {default_reviewer}", file=sys.stderr)
+                    creators.append(default_reviewer)
+
             if creators:
-                print(f"CREATORS={creators}")
+                print(f"CREATORS={','.join(creators)}")
         except Exception:
             print(response_json, file=sys.stderr)
             raise

--- a/linear-extract-reviewers.py
+++ b/linear-extract-reviewers.py
@@ -49,21 +49,21 @@ def main() -> None:
             sys.exit(1)
 
         try:
-            creators = []
-            for ticket_key, response in response_json["data"].items():
+            creators = set()
+            for response in response_json["data"].values():
                 if response.get("creator") and response["creator"].get("email"):
                     email = response["creator"]["email"]
                     if email in email_mapping:
-                        creators.append(email_mapping[email])
+                        creators.add(email_mapping[email])
                     elif default_reviewer:
-                        print(f"The ticket owner for ticket '{ticket_key}' does not appear in the mapping variable. Using default reviewer: {default_reviewer}", file=sys.stderr)
-                        creators.append(default_reviewer)
+                        print(f"The ticket owner does not appear in the mapping variable. Using default reviewer: {default_reviewer}", file=sys.stderr)
+                        creators.add(default_reviewer)
                     else:
-                        print(f"The ticket owner for ticket '{ticket_key}' does not appear in the mapping variable.", file=sys.stderr)
+                        print("The ticket owner does not appear in the mapping variable.", file=sys.stderr)
                         return
                 elif default_reviewer:
-                    print(f"No creator email found for ticket '{ticket_key}'. Using default reviewer: {default_reviewer}", file=sys.stderr)
-                    creators.append(default_reviewer)
+                    print(f"No creator email found for ticket. Using default reviewer: {default_reviewer}", file=sys.stderr)
+                    creators.add(default_reviewer)
                 else:
                     print("No creator email found for ticket and no default reviewer set. Skipping ticket.", file=sys.stderr)
 

--- a/linear-extract-reviewers.py
+++ b/linear-extract-reviewers.py
@@ -50,20 +50,22 @@ def main() -> None:
 
         try:
             creators = []
-            for response in response_json["data"].values():
+            for ticket_key, response in response_json["data"].items():
                 if response.get("creator") and response["creator"].get("email"):
                     email = response["creator"]["email"]
                     if email in email_mapping:
                         creators.append(email_mapping[email])
                     elif default_reviewer:
-                        print(f"The ticket owner does not appear in the mapping variable. Using default reviewer: {default_reviewer}", file=sys.stderr)
+                        print(f"The ticket owner for ticket '{ticket_key}' does not appear in the mapping variable. Using default reviewer: {default_reviewer}", file=sys.stderr)
                         creators.append(default_reviewer)
                     else:
-                        print("The ticket owner does not appear in the mapping variable.", file=sys.stderr)
+                        print(f"The ticket owner for ticket '{ticket_key}' does not appear in the mapping variable.", file=sys.stderr)
                         return
                 elif default_reviewer:
-                    print(f"No creator email found for ticket. Using default reviewer: {default_reviewer}", file=sys.stderr)
+                    print(f"No creator email found for ticket '{ticket_key}'. Using default reviewer: {default_reviewer}", file=sys.stderr)
                     creators.append(default_reviewer)
+                else:
+                    print("No creator email found for ticket and no default reviewer set. Skipping ticket.", file=sys.stderr)
 
             if creators:
                 print(f"CREATORS={','.join(creators)}")


### PR DESCRIPTION
This gracefully handles the situation when an email address is missing from the mapping and it also allows the action to fall back onto a default if defined, while also making it possible to map multiple GH username via a comma seperated like "user1,user2,user3", since using teams directly is difficult given the lack of the proper org-level read permissions.