### PR TITLE
feat: request review from Linear project lead instead of issue creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # add-linear-author-as-reviewer
 
-This project is a GitHub action that requests a review from the Linear issue author.
+This project is a GitHub action that requests a review from the lead of the Linear project the referenced issue belongs to.
 
 Usage example:
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'add-linear-author-as-reviewer'
-description: 'Add Linear author as reviewer'
+description: 'Add the Linear project lead as reviewer'
 author: 'Mergify'
 branding:
   icon: 'at-sign'
@@ -13,7 +13,7 @@ inputs:
     description: 'GitHub Token'
   DEFAULT_REVIEWER:
     required: false
-    description: 'Default GH reviewer if no Linear author found'
+    description: 'Default GH reviewer if no Linear project lead found'
     default: ''
   EMAIL_MAPPING:
     required: true
@@ -39,12 +39,11 @@ runs:
         INPUT_PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
         INPUT_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
     - shell: bash
-      if: "${{ steps.extract.outputs.creators }}"
+      if: "${{ steps.extract.outputs.reviewers }}"
       run: |
         set -x
-        # Split creators string by commas and process each reviewer
-        creators="${{steps.extract.outputs.creators}}"
-        IFS=',' read -ra reviewers <<< "$creators"
+        # Split reviewers string by commas and process each reviewer
+        IFS=',' read -ra reviewers <<< "${{steps.extract.outputs.reviewers}}"
         for reviewer in "${reviewers[@]}"; do
           # Trim whitespace
           reviewer=$(echo "${reviewer}" | xargs)

--- a/linear-extract-reviewers.py
+++ b/linear-extract-reviewers.py
@@ -26,7 +26,7 @@ def main() -> None:
 
     issue_queries = ""
     for linear_id in linear_ids:
-        issue_queries += f'{linear_id.replace("-", "_")}: issue(id: "{linear_id}") {{ creator {{ email }} }} '
+        issue_queries += f'{linear_id.replace("-", "_")}: issue(id: "{linear_id}") {{ project {{ lead {{ email }} }} }} '
 
     query = {"query": f"query {{ {issue_queries} }}"}
     print(query, file=sys.stderr)
@@ -49,26 +49,29 @@ def main() -> None:
             sys.exit(1)
 
         try:
-            creators = set()
+            reviewers = set()
             for response in response_json["data"].values():
-                if response.get("creator") and response["creator"].get("email"):
-                    email = response["creator"]["email"]
+                response = response or {}
+                project = response.get("project") or {}
+                lead = project.get("lead") or {}
+                email = lead.get("email")
+                if email:
                     if email in email_mapping:
-                        creators.add(email_mapping[email])
+                        reviewers.add(email_mapping[email])
                     elif default_reviewer:
-                        print(f"The ticket owner does not appear in the mapping variable. Using default reviewer: {default_reviewer}", file=sys.stderr)
-                        creators.add(default_reviewer)
+                        print(f"The project lead does not appear in the mapping variable. Using default reviewer: {default_reviewer}", file=sys.stderr)
+                        reviewers.add(default_reviewer)
                     else:
-                        print("The ticket owner does not appear in the mapping variable.", file=sys.stderr)
+                        print("The project lead does not appear in the mapping variable.", file=sys.stderr)
                         return
                 elif default_reviewer:
-                    print(f"No creator email found for ticket. Using default reviewer: {default_reviewer}", file=sys.stderr)
-                    creators.add(default_reviewer)
+                    print(f"No project lead email found for ticket. Using default reviewer: {default_reviewer}", file=sys.stderr)
+                    reviewers.add(default_reviewer)
                 else:
-                    print("No creator email found for ticket and no default reviewer set. Skipping ticket.", file=sys.stderr)
+                    print("No project lead email found for ticket and no default reviewer set. Skipping ticket.", file=sys.stderr)
 
-            if creators:
-                print(f"CREATORS={','.join(creators)}")
+            if reviewers:
+                print(f"REVIEWERS={','.join(reviewers)}")
         except Exception:
             print(response_json, file=sys.stderr)
             raise


### PR DESCRIPTION
The action resolved the reviewer from the Linear issue creator
(issue.creator.email). Switch it to the lead of the project the
issue belongs to (issue.project.lead.email), so PRs are routed to
whoever owns the project rather than whoever filed the ticket.

Issues with no project, projects with no lead, and unmapped lead
emails keep the existing EMAIL_MAPPING / DEFAULT_REVIEWER fallback.
The internal output is renamed CREATORS -> REVIEWERS to match.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>