### PR TITLE
ci(mergify): move review gating into merge_protections

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,14 +7,16 @@ shared:
       {{ body }}
     allow_inplace_checks: true
     merge_method: squash
+  DefaultReviewCond: &DefaultReviewCond
+    - "#approved-reviews-by>=1"
+    - author=dependabot[bot]
+    - author=mergify-ci-bot
 queue_rules:
   - name: default
     <<: *DefaultQueueOptions
     queue_conditions:
-      - "#approved-reviews-by>=1"
-      - "#changes-requested-reviews-by=0"
-      - "#review-threads-unresolved=0"
-      - "#review-requested=0"
+      - base=main
+      - -author=dependabot[bot]
     merge_conditions: []
 
   - name: lowprio
@@ -50,5 +52,15 @@ pull_request_rules:
         teams:
           - devs
 
+merge_protections:
+  - name: 👀 Review Requirements
+    if: []
+    success_conditions:
+      - or: *DefaultReviewCond
+
 merge_queue:
   max_parallel_checks: 5
+
+merge_protections_settings:
+  reporting_method: deployments
+  auto_merge_conditions: true


### PR DESCRIPTION
Move the review/approval requirement out of the default queue rule's
queue_conditions into a `👀 Review Requirements` merge protection,
matching mergify-cli and gha-mergify-ci. queue_conditions now route
only: base=main plus a dependabot exclusion so the lowprio rule keeps
its single-commit dependabot PRs. No CI merge protection is added:
this repo is a composite action with no .github/workflows and no
check-success anchor, so nothing gates a PR today except review.

The dropped #changes-requested-reviews-by / #review-threads-unresolved /
#review-requested gates stay enforced via the org `🔎 Reviews` merge
protection inherited through `extends: .github`.

Fixes MRGFY-7755

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>